### PR TITLE
Add option to pass in function for replaceing p_LV and p_RV

### DIFF
--- a/src/circulation/base.py
+++ b/src/circulation/base.py
@@ -77,6 +77,32 @@ def deep_update(d, u):
 
 
 class CirculationModel(ABC):
+    """Base class for circulation models
+
+    Parameters
+    ----------
+    parameters : dict[str, Any] | None, optional
+        Parameters used in the model, by default None which uses the default parameters
+    add_units : bool, optional
+        Add units to the parameters, by default False. Note that adding units
+        will drastically slow down the simulation, so it is recommended to
+        use this only for testing purposes.
+    callback : base.CallBack | None, optional
+        Optional callback function which is called at every time step, by default None.
+        The callback function take three arguments: the model, the current time,
+        and a boolean flag `save` which indicates if the current state should be saved.
+    verbose : bool, optional
+        Print additional information, by default False
+    comm : mpi4py.MPI_InterComm optional
+        MPI communicator, by default None
+    callback_save_state : base.CallBack | None, optional
+        Optional callback function called every time the state should be saved, by default None.
+        The function should take three arguments: the model, the current time, and a boolean
+        flag `save` which indicates if the current state should be saved.
+    initial_state : dict[str, float] | None, optional
+        Initial state of the model, by default None which uses the default initial state
+    """
+
     def __init__(
         self,
         parameters: dict[str, Any] | None = None,

--- a/src/circulation/bestel.py
+++ b/src/circulation/bestel.py
@@ -37,12 +37,12 @@ class BestelActivation:
     Notes
     -----
     The active stress is taken from Bestel et al. [3]_, characterized through
-    a time-dependent stress function \tau solution to the evolution equation
+    a time-dependent stress function :math:`\tau` solution to the evolution equation
 
     .. math::
         \dot{\tau}(t) = -|a(t)|\tau(t) + \sigma_0|a(t)|_+
 
-    being a(\cdot) the activation function and \sigma_0 contractility,
+    with :math:`a(\cdot)` being the activation function and \sigma_0 contractility,
     where each remaining term is described below:
 
     .. math::
@@ -145,7 +145,7 @@ class BestelPressure:
         \dot{p}(t) = -|b(t)|p(t) + \sigma_{\mathrm{mid}}|b(t)|_+
         + \sigma_{\mathrm{pre}}|g_{\mathrm{pre}}(t)|
 
-    being b(\cdot) the activation function described below:
+    with :math:`b(\cdot)` being the activation function described below:
 
     .. math::
         b(t) =& a_{\mathrm{pre}}(t) + \alpha_{\mathrm{pre}}g_{\mathrm{pre}}(t)

--- a/src/circulation/regazzoni2020.py
+++ b/src/circulation/regazzoni2020.py
@@ -20,6 +20,35 @@ class Regazzoni2020(base.CirculationModel):
         closed-loop blood circulation. Part I: model derivation", arXiv (2020)
         https://arxiv.org/abs/2011.15040
 
+    Parameters
+    ----------
+    parameters : dict[str, Any] | None, optional
+        Parameters used in the model, by default None which uses the default parameters
+    p_LV_func : Callable[[float, float], float] | None, optional
+        Optional function to calculate the pressure in the LV, by default None.
+        The function should take the volume in the LV as the first argument and
+        the time as the second argument, and return the pressure in the LV
+    p_BiV_func : Callable[[float, float, float], float] | None, optional
+        Optional function to calculate the pressure in the LV and RV, by default None.
+        The function should take the volume in the LV as the first argument, the volume
+        in the RV as the second argument, and the time as the third argument, and return
+        a tuple (plv, prv) with the pressures in the LV and RV.
+    add_units : bool, optional
+        Add units to the parameters, by default False. Note that adding units
+        will drastically slow down the simulation, so it is recommended to
+        use this only for testing purposes.
+    callback : base.CallBack | None, optional
+        Optional callback function, by default None. The callback function takes
+        three arguments: the model, the current time, and a boolean flag `save`
+        which indicates if the current state should be saved.
+    verbose : bool, optional
+        Print additional information, by default False
+    comm : mpi4py.MPI_InterComm optional
+        MPI communicator, by default None
+    outdir : Path, optional
+        Output directory, by default Path("results-regazzoni")
+    initial_state : dict[str, float] | None, optional
+        Initial state of the model, by default None which uses the default initial state
     """
 
     def __init__(


### PR DESCRIPTION
Here we add the option to pass a function the computed both the LV and RV pressure for a given volume.
The reason for doing it this way, and not supplying one function for each chamber is to make it possible to pass in a function that solves a finite element model and not having to solve the model twice (one for the new LV volume and one for the new RV volume).

In the future we should probably think about if there is better way to do this.